### PR TITLE
[STYLE] Place Popovers Left to avoid off-screen placement

### DIFF
--- a/Classes/Sandstorm/Plumber/Controller/DetailsController.php
+++ b/Classes/Sandstorm/Plumber/Controller/DetailsController.php
@@ -157,6 +157,7 @@ class DetailsController extends AbstractController {
 		$report->render();
 
 		$contents = ob_get_contents();
+		$contents = str_replace('<tbody', '<tbody class="list"', $contents);
 		ob_end_clean();
 
 		$this->view->assign('run', $run);

--- a/Resources/Private/Templates/Overview/Index.html
+++ b/Resources/Private/Templates/Overview/Index.html
@@ -19,7 +19,7 @@
 		$(document).ready(function() {
 			<![CDATA[
 
-			$('a[rel="popover"]').popover({html: true});
+			$('a[rel="popover"]').popover({html: true, placement: 'left'});
 		});
 	]]></script>
 	<style type="text/css">
@@ -67,6 +67,10 @@
 	.brush .resize path {
 		fill: #eee;
 		stroke: #666;
+	}
+
+	.popover {
+		font-size: 13px;
 	}
 	</style>
 </f:section>


### PR DESCRIPTION
This change changes the placement for popovers to left
so they don't go off-screen to the right it it's the last column.

Additionally this sets the font-size to 13px for popovers,
because in some cases the font-size was almost not
readable.
