### PR TITLE
  [BUGFIX] Make PHP 5.4-ready 

### DIFF
--- a/Classes/Sandstorm/Plumber/Controller/AbstractController.php
+++ b/Classes/Sandstorm/Plumber/Controller/AbstractController.php
@@ -23,6 +23,11 @@ abstract class AbstractController extends \TYPO3\Flow\Mvc\Controller\ActionContr
 		\Sandstorm\PhpProfiler\Profiler::getInstance()->stop();
 	}
 
+	/**
+	 * @param string $file
+	 *
+	 * @return \Sandstorm\PhpProfiler\Domain\Model\ProfilingRun
+	 */
 	protected function getProfile($file) {
 		$file = FLOW_PATH_DATA . 'Logs/Profiles/' . $file;
 		$profile = unserialize(file_get_contents($file));

--- a/Classes/Sandstorm/Plumber/Exception.php
+++ b/Classes/Sandstorm/Plumber/Exception.php
@@ -1,0 +1,21 @@
+<?php
+namespace Sandstorm\Plumber;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow package "Sandstorm.Plumber".     *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU General Public License, either version 3          *
+ * of the License, or (at your option) any later version.                 *
+ *                                                                        *
+ * The TYPO3 project - inspiring people to share!                         *
+ *                                                                        */
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * A basic Sandstorm\Plumber-Exception
+ */
+class Exception extends \TYPO3\Flow\Exception {
+
+}
+?>

--- a/Resources/Private/PHP/xhprof-ui/classes/xhprof_ui.php
+++ b/Resources/Private/PHP/xhprof-ui/classes/xhprof_ui.php
@@ -1,14 +1,14 @@
-<?php 
+<?php
 
 class XHProf_UI {
-	
+
 	public $params = array();
 	public $dir = '';
-	
+
 	public $config;
-	
+
 	public $runs = array();
-	
+
 	// default column to sort on -- wall time
 	public $sort = 'wt';
 
@@ -37,13 +37,13 @@ class XHProf_UI {
 
 	function __construct($params, XHProf_UI\Config $config, $dir = null) {
 		$this->params = XHProf_UI\Utils::parse_params($params);
-		
+
 	    // if user hasn't passed a directory location,
 	    // we use the xhprof.output_dir ini setting
 	    // if specified, else we default to the directory
 	    // in which the error_log file resides.
 		if (
-			(!empty($dir) && !is_dir($dir)) || 
+			(!empty($dir) && !is_dir($dir)) ||
 			(empty($dir) && !is_dir($dir = ini_get('xhprof.output_dir')))
 		) {
 			throw new Exception('Warning: Must specify directory location for XHProf runs. '.
@@ -54,7 +54,7 @@ class XHProf_UI {
 
 		$this->dir = $dir;
 	}
-	
+
 	/**
 	 * Generate a XHProf Display View given the various params
 	 *
@@ -81,31 +81,31 @@ class XHProf_UI {
 				if (($data1 = $this->runs[0]->get_data()) && ($data2 = $this->runs[1]->get_data())) {
 					$this->_setup_metrics($data2);
 
-					return new XHProf_UI\Report\Diff(&$this, $data1, $data2);
+					return new XHProf_UI\Report\Diff($this, $data1, $data2);
 				}
-				
+
 			} elseif (count($this->runs) == 1) {
 				if ($data = $this->runs[0]->get_data()) {
 					$this->_setup_metrics($data);
 
-					return new XHProf_UI\Report\Single(&$this, $data);
+					return new XHProf_UI\Report\Single($this, $data);
 				}
 
 			} else {
 				$wts = strlen($wts) > 0 ? explode(',', $wts) : null;
 
-				if ($data = Compute::aggregate_runs(&$this, $this->runs, $wts)) {
+				if ($data = Compute::aggregate_runs($this, $this->runs, $wts)) {
 					$this->_setup_metrics($data);
 
-					return new XHProf_UI\Report\Single(&$this, $data);
+					return new XHProf_UI\Report\Single($this, $data);
 				}
 			}
 		}
 
 		return false;
 	}
-	
-	
+
+
 	public function url(array $params = array()) {
 		return '?'.http_build_query(array_filter(array_merge($this->params, $params)));
 	}
@@ -114,7 +114,7 @@ class XHProf_UI {
 
 	protected function _setup_metrics($data) {
 		extract($this->params, EXTR_SKIP);
-		
+
 		$this->fn = XHProf_UI\Utils::safe_fn($fn);
 
 		if (!empty($sort)) {

--- a/Resources/Private/PHP/xhprof-ui/classes/xhprof_ui/report/driver.php
+++ b/Resources/Private/PHP/xhprof-ui/classes/xhprof_ui/report/driver.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 namespace XHProf_UI\Report;
 
 abstract class Driver {
@@ -6,12 +6,6 @@ abstract class Driver {
 	protected $_ui = array();
 	protected $_data = array();
 
-	/**
-	 * Analyze raw data & generate the profiler report
-	 * abstract class
-	 */
-	abstract public function __construct();
-	
 	abstract public function render();
 
 	protected function _bind($data) {

--- a/Resources/Private/PHP/xhprof-ui/classes/xhprof_ui/report/single.php
+++ b/Resources/Private/PHP/xhprof-ui/classes/xhprof_ui/report/single.php
@@ -1,14 +1,14 @@
-<?php 
+<?php
 namespace XHProf_UI\Report;
 
-use XHProf_UI\Utils, 
-	XHProf_UI\Config, 
+use XHProf_UI\Utils,
+	XHProf_UI\Config,
 	XHProf_UI\Metrics,
 	XHProf_UI\Compute;
 
 class Single extends Driver {
 
-	public function __construct(\XHProf_UI &$ui, array $raw_data) {
+	public function __construct(\XHProf_UI $ui, array $raw_data) {
 		// if we are reporting on a specific function, we can trim down
 		// the report(s) to just stuff that is relevant to this function.
 		// That way compute_flat_info()/compute_diff() etc. do not have
@@ -17,19 +17,19 @@ class Single extends Driver {
 			$raw_data = Compute::trim_run($raw_data, array($ui->fn));
 		}
 
-		$data = Compute::flat_info(&$ui, $raw_data);
+		$data = Compute::flat_info($ui, $raw_data);
 
 		if (!empty($ui->fn) && !isset($data[$ui->fn])) {
 			throw new \Exception('Function '.$ui->fn.' not found in XHProf run');
 		}
-		
+
 		foreach($data as $fn => &$info) {
 			$info = $info + array('fn' => $fn);
 		}
 		uasort($data, function($a, $b) use ($ui) {
 			return Utils::sort_cbk($a, $b, $ui);
 		});
-		
+
 		$this->_ui = $ui;
 		$this->_data = array($raw_data, $data);
 	}
@@ -44,5 +44,5 @@ class Single extends Driver {
 			include XHPROF_ROOT.'/views/report/single.php';
 		}
 	}
-	
+
 }


### PR DESCRIPTION
Made the package ready for PHP 5.4 with mostly
removing "runtime pass-by references" (`&$this`).

Besides, some code is slightly cleaned up and
errors are thrown if the environment does not
match the prerequisites.
