### PR TITLE
Remove dependency to sandstorm/phpprofiler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
 	},
 	"license": "GPL-3.0+",
 	"require":{
-		"typo3/flow":"*",
-		"sandstorm/phpprofiler": "1.1.*"
+		"typo3/flow":"*"
 	},
 	"autoload":{
 		"psr-0":{


### PR DESCRIPTION
Has plumber can be install without PhpProfiler package this commit remove the PhpProfiler dependency from the composer.json
